### PR TITLE
Very simple proof-of-concept packaging of binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 on:
   pull_request:
   push:
+    tags:
     branches:
       - main
-      - master
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -57,6 +57,11 @@ jobs:
           - compiler: llvm
             gcov_executable: "llvm-cov gcov"
 
+          # Set up preferred package generators, for given build configurations
+          - build_type: Release
+            developer_mode: OFF
+            package_generator: TBZ2
+
           # This exists solely to make sure a non-multiconfig build works
           - os: ubuntu-20.04
             compiler: gcc
@@ -85,6 +90,7 @@ jobs:
             generator: "Visual Studio 17 2022"
             build_type: Release
             developer_mode: Off
+            package_generator: ZIP
 
 
 
@@ -131,7 +137,7 @@ jobs:
         # has meaningful results
       - name: Configure CMake
         run: |
-          cmake -S . -B ./build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} -DENABLE_DEVELOPER_MODE:BOOL=${{matrix.developer_mode}} -DOPT_ENABLE_COVERAGE:BOOL=${{ matrix.build_type == 'Debug' }}
+          cmake -S . -B ./build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} -DENABLE_DEVELOPER_MODE:BOOL=${{matrix.developer_mode}} -DOPT_ENABLE_COVERAGE:BOOL=${{ matrix.build_type == 'Debug' }} -DGIT_SHA:STRING=${{ gitub.sha }}
 
       - name: Build
         # Execute the build.  You can specify a specific target with "--target <NAME>"
@@ -154,9 +160,18 @@ jobs:
           OpenCppCoverage.exe --export_type cobertura:coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
 
       - name: CPack
+        if: matrix.package_generator != ''
         working-directory: ./build
         run: |
-          cpack -C ${{matrix.build_type}}
+          cpack -C ${{matrix.build_type}} -G ${{matrix.package_generator}}
+
+      - name: Publish Tagged Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.package_generator != '' }}
+        with:
+          files: |
+            build/*-*${{ matrix.build_type }}*-*.*
+
 
       - name: Publish to codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     tags:
+    release:
+      types: [published]
     branches:
       - main
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,11 @@ jobs:
         run: |
           OpenCppCoverage.exe --export_type cobertura:coverage.xml --cover_children -- ctest -C ${{matrix.build_type}}
 
+      - name: CPack
+        working-directory: ./build
+        run: |
+          cpack -C ${{matrix.build_type}}
+
       - name: Publish to codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         # has meaningful results
       - name: Configure CMake
         run: |
-          cmake -S . -B ./build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} -DENABLE_DEVELOPER_MODE:BOOL=${{matrix.developer_mode}} -DOPT_ENABLE_COVERAGE:BOOL=${{ matrix.build_type == 'Debug' }} -DGIT_SHA:STRING=${{ gitub.sha }}
+          cmake -S . -B ./build -G "${{matrix.generator}}" -DCMAKE_BUILD_TYPE:STRING=${{matrix.build_type}} -DENABLE_DEVELOPER_MODE:BOOL=${{matrix.developer_mode}} -DOPT_ENABLE_COVERAGE:BOOL=${{ matrix.build_type == 'Debug' }} -DGIT_SHA:STRING=${{ github.sha }}
 
       - name: Build
         # Execute the build.  You can specify a specific target with "--target <NAME>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,21 +9,22 @@ set(CMAKE_CXX_STANDARD 20)
 # when compiling with PCH enabled
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-
 # Note: by default ENABLE_DEVELOPER_MODE is True
 # This means that all analysis (sanitizers, static analysis)
 # is enabled and all warnings are treated as errors
 # if you want to switch this behavior, change TRUE to FALSE
-set(ENABLE_DEVELOPER_MODE TRUE CACHE BOOL "Enable 'developer mode'")
+set(ENABLE_DEVELOPER_MODE
+    TRUE
+    CACHE BOOL "Enable 'developer mode'")
 
 # Change this to false if you want to disable warnings_as_errors in developer mode
 set(OPT_WARNINGS_AS_ERRORS_DEVELOPER_DEFAULT TRUE)
 
-# Add project_options v0.15.1
+# Add project_options v0.17.0
 # https://github.com/cpp-best-practices/project_options
 include(FetchContent)
 FetchContent_Declare(_project_options
-                     URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.15.1.zip)
+                     URL https://github.com/cpp-best-practices/project_options/archive/refs/tags/v0.17.0.zip)
 FetchContent_MakeAvailable(_project_options)
 include(${_project_options_SOURCE_DIR}/Index.cmake)
 
@@ -38,6 +39,15 @@ project(
   DESCRIPTION "Starter Project With Best Practices for C++"
   HOMEPAGE_URL "https://github.com/cpp-best-practices/cpp_boilerplate_project"
   LANGUAGES CXX C)
+
+set(GIT_SHA
+    "Unknown"
+    CACHE STRING "SHA this build was generated from")
+string(
+  SUBSTRING "${GIT_SHA}"
+            0
+            8
+            GIT_SHORT_SHA)
 
 get_property(BUILDING_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(BUILDING_MULTI_CONFIG)
@@ -82,18 +92,17 @@ dynamic_project_options(
   PCH_HEADERS
   <vector>
   <string> # This is a list of headers to pre-compile, here are some common ones
-  # CONAN_OPTIONS  # Extra options to pass to conan
-  # MSVC_WARNINGS  # Override the defaults for the MSVC warnings
-  # CLANG_WARNINGS # Override the defaults for the CLANG warnings
-  # GCC_WARNINGS   # Override the defaults for the GCC warnings
+  # CONAN_OPTIONS    # Extra options to pass to conan
+  # MSVC_WARNINGS    # Override the defaults for the MSVC warnings
+  # CLANG_WARNINGS   # Override the defaults for the CLANG warnings
+  # GCC_WARNINGS     # Override the defaults for the GCC warnings
+  # CPPCHECK_OPTIONS # Override the defaults for CppCheck
 )
 
 target_compile_features(project_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 
 # configure files based on CMake configuration options
 add_subdirectory(configured_files)
-target_include_directories(project_options INTERFACE "${CMAKE_BINARY_DIR}")
-
 
 # Adding the src:
 add_subdirectory(src)
@@ -123,5 +132,14 @@ endif()
 # set the startup project for the "play" button in MSVC
 set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT intro)
 
-include(CPack)
+# Add other targets that you want installed here, also
+package_project(TARGETS intro)
 
+# Experience shows that explicit package naming can help make it easier to sort
+# out potential ABI related issues before they start, while helping you
+# track a build to a specific GIT SHA
+set(CPACK_PACKAGE_FILE_NAME
+    "${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION}-${GIT_SHORT_SHA}-${CMAKE_SYSTEM_NAME}-${CMAKE_BUILD_TYPE}-${CMAKE_CXX_COMPILER_ID}-${CMAKE_CXX_COMPILER_VERSION}"
+)
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,3 +122,6 @@ endif()
 
 # set the startup project for the "play" button in MSVC
 set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT intro)
+
+include(CPack)
+

--- a/configured_files/CMakeLists.txt
+++ b/configured_files/CMakeLists.txt
@@ -1,3 +1,7 @@
-configure_file("config.hpp.in" "${CMAKE_BINARY_DIR}/configured_files/config.hpp" ESCAPE_QUOTES)
+
+# A very simple example of a configured file that might need to be
+# converted to one that is publicly installed in the case that
+# you are developing a library
+configure_file("config.hpp.in" "${CMAKE_BINARY_DIR}/configured_files/include/internal_use_only/config.hpp" ESCAPE_QUOTES)
 
 

--- a/configured_files/config.hpp.in
+++ b/configured_files/config.hpp.in
@@ -10,6 +10,7 @@ static constexpr int project_version_major { @PROJECT_VERSION_MAJOR@ };
 static constexpr int project_version_minor { @PROJECT_VERSION_MINOR@ };
 static constexpr int project_version_patch { @PROJECT_VERSION_PATCH@ };
 static constexpr int project_version_tweak { @PROJECT_VERSION_TWEAK@ };
+static constexpr std::string_view git_sha = "@GIT_SHA@";
 }// namespace myproject::cmake
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,3 +12,6 @@ target_link_libraries(
           docopt::docopt
           fmt::fmt
           spdlog::spdlog)
+
+install(TARGETS intro)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 find_package(fmt CONFIG)
 find_package(spdlog CONFIG)
 find_package(docopt CONFIG)
@@ -13,5 +12,5 @@ target_link_libraries(
           fmt::fmt
           spdlog::spdlog)
 
-install(TARGETS intro)
+target_include_directories(intro PRIVATE "${CMAKE_BINARY_DIR}/configured_files/include")
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 // This file will be generated automatically when you run the CMake configuration step.
 // It creates a namespace called `myproject`.
 // You can modify the source template at `configured_files/config.hpp.in`.
-#include <configured_files/config.hpp>
+#include <internal_use_only/config.hpp>
 
 static constexpr auto USAGE =
   R"(Naval Fate.


### PR DESCRIPTION
Related to https://github.com/cpp-best-practices/cpp_boilerplate_project/pull/1, but simplified project changes and enhanced github CI capabilities

Arguably, the CI changes and automated deployment should be moved to
another PR

 * Move to project_options::package_project()
 * *Only* package `intro` target to avoid packaging of test executables
 * Explicitly move configured_files include directory to being a
   `private` dependency of `intro`, since we (at this stage, for an
   executable only project) have no reason to package headers
 * Enhance CPack Package Filename to be explicit on how and from what it
   was built

Changes like this are working very well in
https://github.com/lefticus/json2cpp