### PR TITLE
Add workflow to cleanup after project was created from template

### DIFF
--- a/.github/template/README.md
+++ b/.github/template/README.md
@@ -1,0 +1,16 @@
+# %%myproject%%
+
+[![ci](https://github.com/%%myorg%%/%%myproject%%/actions/workflows/ci.yml/badge.svg)](https://github.com/%%myorg%%/%%myproject%%/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/%%myorg%%/%%myproject%%/branch/main/graph/badge.svg)](https://codecov.io/gh/%%myorg%%/%%myproject%%)
+[![Language grade: C++](https://img.shields.io/lgtm/grade/cpp/github/%%myorg%%/%%myproject%%)](https://lgtm.com/projects/g/%%myorg%%/%%myproject%%/context:cpp)
+
+## About %%myproject%%
+%%description%%
+
+
+## More Details
+
+ * [Dependency Setup](README_dependencies.md)
+ * [Building Details](README_building.md)
+ * [Troubleshooting](README_troubleshooting.md)
+ * [Docker](README_docker.md)

--- a/.github/template/removal-list
+++ b/.github/template/removal-list
@@ -1,0 +1,2 @@
+LICENSE
+.github/FUNDING.yml

--- a/.github/workflows/cleanup-after-create.yml
+++ b/.github/workflows/cleanup-after-create.yml
@@ -43,6 +43,11 @@ jobs:
           sed -i "s/%%description%%/This project does stuff/g" ${{ env.TEMPLATES_PATH }}/README.md
           cp ${{ env.TEMPLATES_PATH }}/README.md README.md
           
+      - name: Remove unwanted files
+        run: |
+          xargs rm -r < ${{ env.TEMPLATES_PATH }}/removal-list
+          xargs ls < ${{ env.TEMPLATES_PATH }}/removal-list || echo "ls failed"
+        
       - name: Just print touched files
         run: |
           # ToDo maybe check if the diff is like we expected?

--- a/.github/workflows/cleanup-after-create.yml
+++ b/.github/workflows/cleanup-after-create.yml
@@ -42,8 +42,7 @@ jobs:
           # fill in placeholders of readme and move it into place
           sed -i "s/%%myorg%%/${{ env.NEW_ORG }}/g" ${{ env.TEMPLATES_PATH }}/README.md
           sed -i "s/%%myproject%%/${{ env.NEW_PROJECT }}/g" ${{ env.TEMPLATES_PATH }}/README.md
-          # ToDo get this info from the repo description
-          sed -i "s/%%description%%/This project does stuff/g" ${{ env.TEMPLATES_PATH }}/README.md
+          sed -i "s/%%description%%/${{ fromJson(steps.get_repo_meta.outputs.data).description }}/g" ${{ env.TEMPLATES_PATH }}/README.md
           cp ${{ env.TEMPLATES_PATH }}/README.md README.md
           
       - name: Remove unwanted files
@@ -57,6 +56,8 @@ jobs:
           git diff CMakeLists.txt
           # diffing the template is more readable then the real readme
           git diff ${{ env.TEMPLATES_PATH }}/README.md
+          # following should not have any diffs
+          diff ${{ env.TEMPLATES_PATH }}/README.md README.md
 
       - name: Clean up before commit and push
         run: |

--- a/.github/workflows/cleanup-after-create.yml
+++ b/.github/workflows/cleanup-after-create.yml
@@ -1,0 +1,65 @@
+# This workflow should cleanup everything unneeded from the template project
+
+name: Cleanup after create
+on:
+  push:
+    branches:
+      - main # maybe all to run "tests" on every change?
+
+env:
+  TEMPLATE_NAME: "cpp_boilerplate_project"
+  TEMPLATES_PATH: ".github/template"
+  
+jobs:
+
+  template-cleanup:
+    name: Cleanup after create
+    runs-on: ubuntu-latest
+    # if a project was created from the cpp_starter_project template the github repository name should differ
+    steps:
+      # Check out current repository
+      - name: Fetch Sources
+        uses: actions/checkout@v2.4.0
+
+      # ToDo use this to check if repo is template
+      #- name: Github Repository Metadata
+       # uses: varunsridharan/action-repository-meta@2.0
+
+      - name: Get organization and project name 
+        run: |
+          echo "NEW_ORG=${{ github.actor }}" >> $GITHUB_ENV
+          echo "NEW_PROJECT=${{ github.event.repository.name }}" >> $GITHUB_ENV
+
+      # Rename all cpp_starter_project occurences to current repository and remove this workflow
+      - name: Insert new org and project
+        run: |
+          # rename the CMake project to match the github project
+          sed -i "s/myproject/${{ github.event.repository.name }}/g" CMakeLists.txt
+          
+          # fill in placeholders of readme and move it into place
+          sed -i "s/%%myorg%%/${{ env.NEW_ORG }}/g" ${{ env.TEMPLATES_PATH }}/README.md
+          sed -i "s/%%myproject%%/${{ env.NEW_PROJECT }}/g" ${{ env.TEMPLATES_PATH }}/README.md
+          sed -i "s/%%description%%/This project does stuff/g" ${{ env.TEMPLATES_PATH }}/README.md
+          mv ${{ env.TEMPLATES_PATH }}/README.md README.md
+          
+      - name: Just print touched files
+        run: |
+          cat README.md
+
+      - name: Clean up before commit and push
+        run: |
+          rm -rf ${{ env.TEMPLATES_PATH }}
+
+          # Can we get that from a variabl?
+          # Remove this workflow as it has fulfilled its purpose
+          rm -rf .github/workflows/cleanup-after-create.yml
+
+      - uses: EndBug/add-and-commit@v4
+        # only commit and push if we are not the template project anymore!
+        if: github.event.repository.name != env.TEMPLATE_NAME
+        with:
+          author_name: Cleanup Robot
+          author_email: template.cleanup@example.com
+          message: 'Cleanup template and initialize repository'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-after-create.yml
+++ b/.github/workflows/cleanup-after-create.yml
@@ -15,21 +15,24 @@ jobs:
   template-cleanup:
     name: Cleanup after create
     runs-on: ubuntu-latest
-    # if a project was created from the cpp_starter_project template the github repository name should differ
     steps:
-      # Check out current repository
       - name: Fetch Sources
         uses: actions/checkout@v2.4.0
-
-      # ToDo use this to check if repo is template
-      #- name: Github Repository Metadata
-       # uses: varunsridharan/action-repository-meta@2.0
 
       - name: Get organization and project name 
         run: |
           echo "NEW_ORG=${{ github.actor }}" >> $GITHUB_ENV
           echo "NEW_PROJECT=${{ github.event.repository.name }}" >> $GITHUB_ENV
 
+      - uses: octokit/request-action@v2.x
+        id: get_repo_meta
+        with:
+          route: GET /repos/{owner}/{repo}
+          owner: ${{ env.NEW_ORG }}
+          repo: ${{ env.NEW_PROJECT }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
       # Rename all cpp_starter_project occurences to current repository and remove this workflow
       - name: Insert new org and project
         run: |
@@ -64,8 +67,8 @@ jobs:
           rm -rf .github/workflows/cleanup-after-create.yml
 
       - uses: EndBug/add-and-commit@v4
-        # only commit and push if we are not the template project anymore!
-        if: github.event.repository.name != env.TEMPLATE_NAME
+        # only commit and push if we are not a template project anymore!
+        if: fromJson(steps.get_repo_meta.outputs.data).is_template != true
         with:
           author_name: Cleanup Robot
           author_email: template.cleanup@example.com

--- a/.github/workflows/cleanup-after-create.yml
+++ b/.github/workflows/cleanup-after-create.yml
@@ -7,7 +7,6 @@ on:
       - main # maybe all to run "tests" on every change?
 
 env:
-  TEMPLATE_NAME: "cpp_boilerplate_project"
   TEMPLATES_PATH: ".github/template"
   
 jobs:

--- a/.github/workflows/cleanup-after-create.yml
+++ b/.github/workflows/cleanup-after-create.yml
@@ -39,12 +39,16 @@ jobs:
           # fill in placeholders of readme and move it into place
           sed -i "s/%%myorg%%/${{ env.NEW_ORG }}/g" ${{ env.TEMPLATES_PATH }}/README.md
           sed -i "s/%%myproject%%/${{ env.NEW_PROJECT }}/g" ${{ env.TEMPLATES_PATH }}/README.md
+          # ToDo get this info from the repo description
           sed -i "s/%%description%%/This project does stuff/g" ${{ env.TEMPLATES_PATH }}/README.md
-          mv ${{ env.TEMPLATES_PATH }}/README.md README.md
+          cp ${{ env.TEMPLATES_PATH }}/README.md README.md
           
       - name: Just print touched files
         run: |
-          cat README.md
+          # ToDo maybe check if the diff is like we expected?
+          git diff CMakeLists.txt
+          # diffing the template is more readable then the real readme
+          git diff ${{ env.TEMPLATES_PATH }}/README.md
 
       - name: Clean up before commit and push
         run: |

--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -1,6 +1,6 @@
 # This workflow should cleanup everything unneeded from the template project
 
-name: Cleanup after create
+name: Template Janitor
 on:
   push:
     branches:
@@ -44,19 +44,17 @@ jobs:
           sed -i "s/%%description%%/${{ fromJson(steps.get_repo_meta.outputs.data).description }}/g" ${{ env.TEMPLATES_PATH }}/README.md
           cp ${{ env.TEMPLATES_PATH }}/README.md README.md
           
-      - name: Remove unwanted files
+      - name: Print diff after replacement
         run: |
-          xargs rm -r < ${{ env.TEMPLATES_PATH }}/removal-list
-          xargs ls < ${{ env.TEMPLATES_PATH }}/removal-list || echo "ls failed"
-        
-      - name: Just print touched files
-        run: |
-          # ToDo maybe check if the diff is like we expected?
-          git diff CMakeLists.txt
-          # diffing the template is more readable then the real readme
-          git diff ${{ env.TEMPLATES_PATH }}/README.md
+          # Exclude the README as that is checked seperatly!
+          git diff ':!README.md'
           # following should not have any diffs
           diff ${{ env.TEMPLATES_PATH }}/README.md README.md
+
+      - name: Remove unwanted files
+        run: |
+          # No tests needed as this will fail if any file from the list is missing/misspelled
+          xargs rm -r < ${{ env.TEMPLATES_PATH }}/removal-list
 
       - name: Clean up before commit and push
         run: |
@@ -64,14 +62,14 @@ jobs:
 
           # Can we get that from a variabl?
           # Remove this workflow as it has fulfilled its purpose
-          rm -rf .github/workflows/cleanup-after-create.yml
+          rm -rf .github/workflows/template-janitor.yml
 
       - uses: EndBug/add-and-commit@v4
         # only commit and push if we are not a template project anymore!
         if: fromJson(steps.get_repo_meta.outputs.data).is_template != true
         with:
-          author_name: Cleanup Robot
-          author_email: template.cleanup@example.com
+          author_name: Template Janitor
+          author_email: template.janitor@example.com
           message: 'Cleanup template and initialize repository'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Insert new org and project
         run: |
           # rename the CMake project to match the github project
-          sed -i "s/myproject/${{ github.event.repository.name }}/g" CMakeLists.txt
+          sed -i "s/myproject/${{ github.event.repository.name }}/gi" CMakeLists.txt configured_files/config.hpp.in
           
           # fill in placeholders of readme and move it into place
           sed -i "s/%%myorg%%/${{ env.NEW_ORG }}/g" ${{ env.TEMPLATES_PATH }}/README.md

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This will take you to Github's ['Generate Repository'](https://github.com/cpp-be
 Fill in a repository name and short description, and click 'Create repository from template'.
 This will allow you to create a new repository in your Github account,
 prepopulated with the contents of this project.
+
+After creating the project please wait until the cleanup workflow has finished 
+setting up your project and commited the changes.
+
 Now you can clone the project locally and get to work!
 
     git clone https://github.com/<user>/<your_new_repo>.git


### PR DESCRIPTION
This PR was moved from the cpp_starter_project (https://github.com/cpp-best-practices/cpp_starter_project/pull/197).
This PR implements a first simple workflow to do some cleanup inspired by cpp-best-practices/cpp_boilerplate_project#5.

As https://github.com/github/feedback/discussions/5336 is not implemented by github, this PR should workaround that need for a template project. 

Goals of this PR:
- [x] cleanup build badges when project is created from template and remove the worklfow from the project
- [x] allow to make forks to contribute to the template without triggering the workflow: Use the information if the repository is a template for this
- [x] make it possible to create another template based on this template with correct build badges easily or automatically (better: don't make it impossible): Use the information if the repository is a template for this
- [x] rename the cmake project when project is created 
- [x] remove LICENSE file so new project is not by default Public Domain, and encourage user to place their own
- [x] remove funding.yml file so new project doesn't implicitly point back to @lefticus
- [x] consider a README-Template.md that is easier to regex replace from and use that to replace existing README.md This might make setup and maintenance easier?
- [x] Test: on template repo run the workflow with random variables to check it is working and just omit the push into the repository 
- [ ] Probably have the diffs of the commit checked when run on the project template (those should be deterministic)
- [x] Use repo description to fill in a placeholder inside the README template