### PR TITLE
Feature/ninja multi presets support

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,18 +7,18 @@
     },
     "configurePresets": [
         {
-            "name": "conf-common",
+            "name": "config-common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
-            "generator": "Ninja",
+            "generator": "Ninja Multi-Config",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "installDir": "${sourceDir}/out/install/${presetName}"
         },
         {
-            "name": "conf-windows-common",
+            "name": "config-windows-common",
             "description": "Windows settings for MSBuild toolchain that apply to msvc and clang",
             "hidden": true,
-            "inherits": "conf-common",
+            "inherits": "config-common",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -34,10 +34,10 @@
             }
         },
         {
-            "name": "conf-linux-common",
+            "name": "config-linux-common",
             "description": "Linux settings for gcc and clang toolchains",
             "hidden": true,
-            "inherits": "conf-common",
+            "inherits": "config-common",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -50,10 +50,10 @@
             }
         },
         {
-            "name": "windows-msvc-debug",
-            "displayName": "msvc Debug",
+            "name": "windows-msvc",
+            "displayName": "msvc",
             "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
@@ -61,21 +61,10 @@
             }
         },
         {
-            "name": "windows-msvc-release",
-            "displayName": "msvc Release",
-            "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "windows-clang-debug",
-            "displayName": "clang Debug",
+            "name": "windows-clang",
+            "displayName": "clang",
             "description": "Target Windows with the clang compiler, debug build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang-cl",
                 "CMAKE_CXX_COMPILER": "clang-cl",
@@ -88,26 +77,10 @@
             }
         },
         {
-            "name": "windows-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Windows with the clang compiler, release build type",
-            "inherits": "conf-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-clang-x64"
-                }
-            }
-        },
-        {
-            "name": "linux-gcc-debug",
-            "displayName": "gcc Debug",
+            "name": "linux-gcc",
+            "displayName": "gcc",
             "description": "Target Linux with the gcc compiler, debug build type",
-            "inherits": "conf-linux-common",
+            "inherits": "config-linux-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
@@ -115,37 +88,71 @@
             }
         },
         {
-            "name": "linux-gcc-release",
-            "displayName": "gcc Release",
-            "description": "Target Linux with the gcc compiler, release build type",
-            "inherits": "conf-linux-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "linux-clang-debug",
-            "displayName": "clang Debug",
+            "name": "linux-clang",
+            "displayName": "clang",
             "description": "Target Linux with the clang compiler, debug build type",
-            "inherits": "conf-linux-common",
+            "inherits": "config-linux-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_BUILD_TYPE": "Debug"
             }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "build-common-debug",
+            "description": "Set build type to Debug",
+            "hidden": true,
+            "configuration": "Debug"
         },
         {
-            "name": "linux-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Linux with the clang compiler, release build type",
-            "inherits": "conf-linux-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
+            "name": "build-common-release",
+            "description": "Set build type to Release",
+            "hidden": true,
+            "configuration": "Release"
+        },
+        {
+            "name": "build-windows-msvc-debug",
+            "displayName": "Debug",
+            "description": "Build msvc debug on windows",
+            "inherits": "build-common-debug",
+            "configurePreset": "windows-msvc"
+        },
+        {
+            "name": "build-windows-msvc-release",
+            "displayName": "Release",
+            "description": "Build msvc release on windows",
+            "inherits": "build-common-release",
+            "configurePreset": "windows-msvc"
+        },
+        {
+        "name": "build-linux-gcc-debug",
+        "displayName": "Debug",
+        "description": "Build gcc debug on linux",
+        "inherits": "build-common-debug",
+        "configurePreset": "linux-gcc"
+    },
+    {
+        "name": "build-linux-gcc-release",
+        "displayName": "Release",
+        "description": "Build gcc release on linux",
+        "inherits": "build-common-release",
+        "configurePreset": "linux-gcc"
+    },
+    {
+        "name": "build-linux-clang-debug",
+        "displayName": "Debug",
+        "description": "Build clang debug on linux",
+        "inherits": "build-common-debug",
+        "configurePreset": "linux-clang"
+    },
+    {
+        "name": "build-linux-clang-release",
+        "displayName": "Release",
+        "description": "Build clang release on linux",
+        "inherits": "build-common-release",
+        "configurePreset": "linux-clang"
         }
     ],
     "testPresets": [
@@ -162,60 +169,60 @@
             }
         },
         {
-            "name": "test-windows-msvc-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug"
+        "name": "test-common-debug",
+        "description": "Test CMake settings that apply to debug configurations",
+        "hidden": true,
+        "inherits": "test-common",
+        "configuration": "Debug"
         },
         {
-            "name": "test-windows-msvc-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-msvc-release"
+        "name": "test-common-release",
+        "description": "Test CMake settings that apply to release configurations",
+        "hidden": true,
+        "inherits": "test-common",
+        "configuration": "Release"
         },
         {
-            "name": "test-windows-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-clang-debug"
+        "name": "test-windows-msvc-debug",
+        "displayName": "Debug",
+        "description": "Set Strict rules for windows msvc debug tests",
+        "inherits": "test-common-debug",
+        "configurePreset": "windows-msvc"
         },
         {
-            "name": "test-windows-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-clang-release"
+        "name": "test-windows-msvc-release",
+        "displayName": "Release",
+        "description": "Set Strict rules for windows msvc release tests",
+        "inherits": "test-common-release",
+        "configurePreset": "windows-msvc"
         },
         {
-            "name": "test-linux-gcc-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "linux-gcc-debug"
+        "name": "test-linux-gcc-debug",
+        "displayName": "Debug",
+        "description": "Set Strict rules for linux gcc debug tests",
+        "inherits": "test-common-debug",
+        "configurePreset": "linux-gcc"
         },
         {
-            "name": "test-linux-gcc-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "linux-gcc-release"
+        "name": "test-linux-gcc-release",
+        "displayName": "Release",
+        "description": "Set Strict rules for linux gcc release tests",
+        "inherits": "test-common-release",
+        "configurePreset": "linux-gcc"
         },
         {
-            "name": "test-linux-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "linux-clang-debug"
+        "name": "test-linux-clang-debug",
+        "displayName": "Debug",
+        "description": "Set Strict rules for linux clang debug tests",
+        "inherits": "test-common-debug",
+        "configurePreset": "linux-clang"
         },
         {
-            "name": "test-linux-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "linux-clang-release"
+        "name": "test-linux-clang-release",
+        "displayName": "Release",
+        "description": "Set Strict rules for linux clang release tests",
+        "inherits": "test-common-release",
+        "configurePreset": "linux-clang"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -135,32 +135,32 @@
             "configurePreset": "windows-msvc"
         },
         {
-        "name": "build-linux-gcc-debug",
-        "displayName": "Debug",
-        "description": "Build gcc debug on linux",
-        "inherits": "build-common-debug",
-        "configurePreset": "linux-gcc"
-    },
-    {
-        "name": "build-linux-gcc-release",
-        "displayName": "Release",
-        "description": "Build gcc release on linux",
-        "inherits": "build-common-release",
-        "configurePreset": "linux-gcc"
-    },
-    {
-        "name": "build-linux-clang-debug",
-        "displayName": "Debug",
-        "description": "Build clang debug on linux",
-        "inherits": "build-common-debug",
-        "configurePreset": "linux-clang"
-    },
-    {
-        "name": "build-linux-clang-release",
-        "displayName": "Release",
-        "description": "Build clang release on linux",
-        "inherits": "build-common-release",
-        "configurePreset": "linux-clang"
+            "name": "build-linux-gcc-debug",
+            "displayName": "Debug",
+            "description": "Build gcc debug on linux",
+            "inherits": "build-common-debug",
+            "configurePreset": "linux-gcc"
+        },
+        {
+            "name": "build-linux-gcc-release",
+            "displayName": "Release",
+            "description": "Build gcc release on linux",
+            "inherits": "build-common-release",
+            "configurePreset": "linux-gcc"
+        },
+        {
+            "name": "build-linux-clang-debug",
+            "displayName": "Debug",
+            "description": "Build clang debug on linux",
+            "inherits": "build-common-debug",
+            "configurePreset": "linux-clang"
+        },
+        {
+            "name": "build-linux-clang-release",
+            "displayName": "Release",
+            "description": "Build clang release on linux",
+            "inherits": "build-common-release",
+            "configurePreset": "linux-clang"
         }
     ],
     "testPresets": [
@@ -177,60 +177,60 @@
             }
         },
         {
-        "name": "test-common-debug",
-        "description": "Test CMake settings that apply to debug configurations",
-        "hidden": true,
-        "inherits": "test-common",
-        "configuration": "Debug"
+            "name": "test-common-debug",
+            "description": "Test CMake settings that apply to debug configurations",
+            "hidden": true,
+            "inherits": "test-common",
+            "configuration": "Debug"
         },
         {
-        "name": "test-common-release",
-        "description": "Test CMake settings that apply to release configurations",
-        "hidden": true,
-        "inherits": "test-common",
-        "configuration": "Release"
+            "name": "test-common-release",
+            "description": "Test CMake settings that apply to release configurations",
+            "hidden": true,
+            "inherits": "test-common",
+            "configuration": "Release"
         },
         {
-        "name": "test-windows-msvc-debug",
-        "displayName": "Debug",
-        "description": "Set Strict rules for windows msvc debug tests",
-        "inherits": "test-common-debug",
-        "configurePreset": "windows-msvc"
+            "name": "test-windows-msvc-debug",
+            "displayName": "Debug",
+            "description": "Set Strict rules for windows msvc debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "windows-msvc"
         },
         {
-        "name": "test-windows-msvc-release",
-        "displayName": "Release",
-        "description": "Set Strict rules for windows msvc release tests",
-        "inherits": "test-common-release",
-        "configurePreset": "windows-msvc"
+            "name": "test-windows-msvc-release",
+            "displayName": "Release",
+            "description": "Set Strict rules for windows msvc release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "windows-msvc"
         },
         {
-        "name": "test-linux-gcc-debug",
-        "displayName": "Debug",
-        "description": "Set Strict rules for linux gcc debug tests",
-        "inherits": "test-common-debug",
-        "configurePreset": "linux-gcc"
+            "name": "test-linux-gcc-debug",
+            "displayName": "Debug",
+            "description": "Set Strict rules for linux gcc debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "linux-gcc"
         },
         {
-        "name": "test-linux-gcc-release",
-        "displayName": "Release",
-        "description": "Set Strict rules for linux gcc release tests",
-        "inherits": "test-common-release",
-        "configurePreset": "linux-gcc"
+            "name": "test-linux-gcc-release",
+            "displayName": "Release",
+            "description": "Set Strict rules for linux gcc release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "linux-gcc"
         },
         {
-        "name": "test-linux-clang-debug",
-        "displayName": "Debug",
-        "description": "Set Strict rules for linux clang debug tests",
-        "inherits": "test-common-debug",
-        "configurePreset": "linux-clang"
+            "name": "test-linux-clang-debug",
+            "displayName": "Debug",
+            "description": "Set Strict rules for linux clang debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "linux-clang"
         },
         {
-        "name": "test-linux-clang-release",
-        "displayName": "Release",
-        "description": "Set Strict rules for linux clang release tests",
-        "inherits": "test-common-release",
-        "configurePreset": "linux-clang"
+            "name": "test-linux-clang-release",
+            "displayName": "Release",
+            "description": "Set Strict rules for linux clang release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "linux-clang"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,6 +58,11 @@
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "vendor": {
+                "jetbrains.com/clion": {
+                    "toolchain": "Visual Studio"
+                }
             }
         },
         {
@@ -73,6 +78,9 @@
             "vendor": {
                 "microsoft.com/VisualStudioSettings/CMake/1.0": {
                     "intelliSenseMode": "windows-clang-x64"
+                },
+                "jetbrains.com/clion": {
+                    "toolchain": "Visual Studio"
                 }
             }
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,9 +10,7 @@
             "name": "config-common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
-            "generator": "Ninja Multi-Config",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}"
+            "generator": "Ninja Multi-Config"
         },
         {
             "name": "config-windows-common",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,7 +52,7 @@
         {
             "name": "windows-msvc",
             "displayName": "msvc",
-            "description": "Target Windows with the msvc compiler, debug build type",
+            "description": "Target Windows with the msvc compiler",
             "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
@@ -68,7 +68,7 @@
         {
             "name": "windows-clang",
             "displayName": "clang",
-            "description": "Target Windows with the clang compiler, debug build type",
+            "description": "Target Windows with the clang compiler",
             "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang-cl",
@@ -87,7 +87,7 @@
         {
             "name": "linux-gcc",
             "displayName": "gcc",
-            "description": "Target Linux with the gcc compiler, debug build type",
+            "description": "Target Linux with the gcc compiler",
             "inherits": "config-linux-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
@@ -98,7 +98,7 @@
         {
             "name": "linux-clang",
             "displayName": "clang",
-            "description": "Target Linux with the clang compiler, debug build type",
+            "description": "Target Linux with the clang compiler",
             "inherits": "config-linux-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",


### PR DESCRIPTION
In the first CMake presets integration I used Ninja as the default generator for the presets https://github.com/cpp-best-practices/cpp_starter_project/pull/175#issuecomment-1019229035.
With those changes "Ninja Multi-Config" generator was made as the default. That will have as a result a faster switch time between Debug and Release builds and will also be consistent with the CI that also uses this generator.
P.S. @lefticus this might be useful for the Game Jam! not mandatory though. 