### PR TITLE
Add support for macOS X host to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,6 +54,17 @@
             }
         },
         {
+            "name": "conf-darwin-common",
+            "description": "Darwin (macOS) settings for AppleClang tooolchain",
+            "hidden": true,
+            "inherits": "conf-common",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
             "name": "windows-msvc-debug-developer-mode",
             "displayName": "msvc Debug (Developer Mode)",
             "description": "Target Windows with the msvc compiler, debug build type",
@@ -75,7 +86,7 @@
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "ENABLE_DEVELOPER_MODE": "ON"
-             }
+            }
         },
         {
             "name": "windows-msvc-debug-user-mode",
@@ -87,7 +98,7 @@
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_BUILD_TYPE": "Debug",
                 "ENABLE_DEVELOPER_MODE": "OFF"
-             }
+            }
         },
         {
             "name": "windows-msvc-release-user-mode",
@@ -99,7 +110,7 @@
                 "CMAKE_CXX_COMPILER": "cl",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
                 "ENABLE_DEVELOPER_MODE": "OFF"
-             }
+            }
         },
         {
             "name": "windows-clang-debug",
@@ -176,6 +187,28 @@
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
+        },
+        {
+            "name": "darwin-clang-debug",
+            "displayName": "AppleClang Debug",
+            "description": "Target Darwin (macOS) with the AppleCalng compiler, debug build type",
+            "inherits": "conf-darwin-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "darwin-clang-release",
+            "displayName": "AppleClang Release",
+            "description": "Target Darwin (macOS) with the AppleCalng compiler, release build type",
+            "inherits": "conf-darwin-common",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
         }
     ],
     "testPresets": [
@@ -246,6 +279,20 @@
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
             "configurePreset": "linux-clang-release"
+        },
+        {
+            "name": "test-darwin-clang-debug",
+            "displayName": "Strict",
+            "description": "Enable output and stop on failure",
+            "inherits": "test-common",
+            "configurePreset": "darwin-clang-debug"
+        },
+        {
+            "name": "test-darwin-clang-release",
+            "displayName": "Strict",
+            "description": "Enable output and stop on failure",
+            "inherits": "test-common",
+            "configurePreset": "darwin-clang-release"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,30 +38,22 @@
             }
         },
         {
-            "name": "conf-linux-common",
-            "description": "Linux settings for gcc and clang toolchains",
+            "name": "conf-unixlike-common",
+            "description": "Unix-like OS settings for gcc and clang toolchains",
             "hidden": true,
             "inherits": "conf-common",
             "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
+                "type": "inList",
+                "string": "${hostSystemName}",
+                "list": [
+                    "Linux",
+                    "Darwin"
+                ]
             },
             "vendor": {
                 "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
                     "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
                 }
-            }
-        },
-        {
-            "name": "conf-darwin-common",
-            "description": "Darwin (macOS) settings for AppleClang tooolchain",
-            "hidden": true,
-            "inherits": "conf-common",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Darwin"
             }
         },
         {
@@ -145,10 +137,10 @@
             }
         },
         {
-            "name": "linux-gcc-debug",
+            "name": "unixlike-gcc-debug",
             "displayName": "gcc Debug",
-            "description": "Target Linux with the gcc compiler, debug build type",
-            "inherits": "conf-linux-common",
+            "description": "Target Unix-like OS with the gcc compiler, debug build type",
+            "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
@@ -156,10 +148,10 @@
             }
         },
         {
-            "name": "linux-gcc-release",
+            "name": "unixlike-gcc-release",
             "displayName": "gcc Release",
-            "description": "Target Linux with the gcc compiler, release build type",
-            "inherits": "conf-linux-common",
+            "description": "Target Unix-like OS with the gcc compiler, release build type",
+            "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
@@ -167,10 +159,10 @@
             }
         },
         {
-            "name": "linux-clang-debug",
+            "name": "unixlike-clang-debug",
             "displayName": "clang Debug",
-            "description": "Target Linux with the clang compiler, debug build type",
-            "inherits": "conf-linux-common",
+            "description": "Target Unix-like OS with the clang compiler, debug build type",
+            "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
@@ -178,32 +170,10 @@
             }
         },
         {
-            "name": "linux-clang-release",
+            "name": "unixlike-clang-release",
             "displayName": "clang Release",
-            "description": "Target Linux with the clang compiler, release build type",
-            "inherits": "conf-linux-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "darwin-clang-debug",
-            "displayName": "AppleClang Debug",
-            "description": "Target Darwin (macOS) with the AppleCalng compiler, debug build type",
-            "inherits": "conf-darwin-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "darwin-clang-release",
-            "displayName": "AppleClang Release",
-            "description": "Target Darwin (macOS) with the AppleCalng compiler, release build type",
-            "inherits": "conf-darwin-common",
+            "description": "Target Unix-like OS with the clang compiler, release build type",
+            "inherits": "conf-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
@@ -253,46 +223,32 @@
             "configurePreset": "windows-clang-release"
         },
         {
-            "name": "test-linux-gcc-debug",
+            "name": "test-unixlike-gcc-debug",
             "displayName": "Strict",
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
-            "configurePreset": "linux-gcc-debug"
+            "configurePreset": "unixlike-gcc-debug"
         },
         {
-            "name": "test-linux-gcc-release",
+            "name": "test-unixlike-gcc-release",
             "displayName": "Strict",
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
-            "configurePreset": "linux-gcc-release"
+            "configurePreset": "unixlike-gcc-release"
         },
         {
-            "name": "test-linux-clang-debug",
+            "name": "test-unixlike-clang-debug",
             "displayName": "Strict",
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
-            "configurePreset": "linux-clang-debug"
+            "configurePreset": "unixlike-clang-debug"
         },
         {
-            "name": "test-linux-clang-release",
+            "name": "test-unixlike-clang-release",
             "displayName": "Strict",
             "description": "Enable output and stop on failure",
             "inherits": "test-common",
-            "configurePreset": "linux-clang-release"
-        },
-        {
-            "name": "test-darwin-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "darwin-clang-debug"
-        },
-        {
-            "name": "test-darwin-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "darwin-clang-release"
+            "configurePreset": "unixlike-clang-release"
         }
     ]
 }


### PR DESCRIPTION
Hi everyone,

This PR has been migrated from https://github.com/cpp-best-practices/ftxui_template/pull/7

It tries to solve the following issue: Linux and Windows configure presets cannot be used with Darwin-based platforms (such as macOS X). The discussion started in the ftxui_template project may be still relevant here.