### PR TITLE
Feature/presets enchancements

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,6 +55,47 @@
             }
         },
         {
+            "name": "config-msvc-compiler",
+            "description": "Set cl as the compiler to be used",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "cl",
+                "CMAKE_CXX_COMPILER": "cl"
+            }
+        },
+        {
+            "name": "config-clangcl-compiler",
+            "description": "Set clang-cl as the compiler to be used",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang-cl",
+                "CMAKE_CXX_COMPILER": "clang-cl"
+            },
+            "vendor": {
+                "microsoft.com/VisualStudioSettings/CMake/1.0": {
+                    "intelliSenseMode": "windows-clang-x64"
+                }
+            }
+        },
+        {
+            "name": "config-gcc-compiler",
+            "description": "Set gcc as the compiler to be used",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
+            }
+        },
+        {
+            "name": "config-clang-compiler",
+            "description": "Set clang as the compiler to be used",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++"
+            }
+        },
+        {
             "name": "config-developer-mode",
             "description": "Set the flags to enable the development mode",
             "hidden": true,
@@ -76,13 +117,9 @@
             "description": "Target Windows with the msvc compiler using Developer Mode",
             "inherits": [
                 "config-windows-common",
+                "config-msvc-compiler",
                 "config-developer-mode"
-            ],
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
+            ]
         },
         {
             "name": "windows-msvc-user",
@@ -90,51 +127,36 @@
             "description": "Target Windows with the msvc compiler using User Mode",
             "inherits": [
                 "config-windows-common",
+                "config-msvc-compiler",
                 "config-user-mode"
-            ],
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
+            ]
         },
         {
             "name": "windows-clang",
             "displayName": "clang",
             "description": "Target Windows with the clang compiler",
-            "inherits": "config-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl",
-                "CMAKE_BUILD_TYPE": "Debug"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-clang-x64"
-                }
-            }
+            "inherits": [
+                "config-windows-common",
+                "config-clangcl-compiler"
+            ]
         },
         {
             "name": "unixlike-gcc",
             "displayName": "gcc",
             "description": "Target Unix-like OS with the gcc compiler",
-            "inherits": "config-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
+            "inherits": [
+                "config-unixlike-common",
+                "config-gcc-compiler"
+            ]
         },
         {
             "name": "unixlike-clang",
             "displayName": "clang",
             "description": "Target Unix-like OS with the clang compiler",
-            "inherits": "config-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
+            "inherits": [
+                "config-unixlike-common",
+                "config-clang-compiler"
+            ]
         }
     ],
     "buildPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
             "name": "config-common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
-            "generator": "Ninja"
+            "generator": "Ninja Multi-Config"
         },
         {
             "name": "config-windows-common",
@@ -71,9 +71,9 @@
             }
         },
         {
-            "name": "windows-msvc-debug-developer-mode",
-            "displayName": "msvc Debug (Developer Mode)",
-            "description": "Target Windows with the msvc compiler, debug build type",
+            "name": "windows-msvc-developer",
+            "displayName": "msvc (Developer Mode)",
+            "description": "Target Windows with the msvc compiler using Developer Mode",
             "inherits": [
                 "config-windows-common",
                 "config-developer-mode"
@@ -85,23 +85,9 @@
             }
         },
         {
-            "name": "windows-msvc-release-developer-mode",
-            "displayName": "msvc Release (Developer Mode)",
-            "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": [
-                "config-windows-common",
-                "config-developer-mode"
-            ],
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "windows-msvc-debug-user-mode",
-            "displayName": "msvc Debug (User Mode)",
-            "description": "Target Windows with the msvc compiler, debug build type",
+            "name": "windows-msvc-user",
+            "displayName": "msvc (User Mode)",
+            "description": "Target Windows with the msvc compiler using User Mode",
             "inherits": [
                 "config-windows-common",
                 "config-user-mode"
@@ -113,23 +99,9 @@
             }
         },
         {
-            "name": "windows-msvc-release-user-mode",
-            "displayName": "msvc Release (User Mode)",
-            "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": [
-                "config-windows-common",
-                "config-user-mode"
-            ],
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "windows-clang-debug",
-            "displayName": "clang Debug",
-            "description": "Target Windows with the clang compiler, debug build type",
+            "name": "windows-clang",
+            "displayName": "clang",
+            "description": "Target Windows with the clang compiler",
             "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang-cl",
@@ -143,25 +115,9 @@
             }
         },
         {
-            "name": "windows-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Windows with the clang compiler, release build type",
-            "inherits": "config-windows-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
-            "vendor": {
-                "microsoft.com/VisualStudioSettings/CMake/1.0": {
-                    "intelliSenseMode": "windows-clang-x64"
-                }
-            }
-        },
-        {
-            "name": "unixlike-gcc-debug",
-            "displayName": "gcc Debug",
-            "description": "Target Unix-like OS with the gcc compiler, debug build type",
+            "name": "unixlike-gcc",
+            "displayName": "gcc",
+            "description": "Target Unix-like OS with the gcc compiler",
             "inherits": "config-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
@@ -170,37 +126,91 @@
             }
         },
         {
-            "name": "unixlike-gcc-release",
-            "displayName": "gcc Release",
-            "description": "Target Unix-like OS with the gcc compiler, release build type",
-            "inherits": "config-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
-        },
-        {
-            "name": "unixlike-clang-debug",
-            "displayName": "clang Debug",
-            "description": "Target Unix-like OS with the clang compiler, debug build type",
+            "name": "unixlike-clang",
+            "displayName": "clang",
+            "description": "Target Unix-like OS with the clang compiler",
             "inherits": "config-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
                 "CMAKE_BUILD_TYPE": "Debug"
             }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "build-common-debug",
+            "description": "Set build type to Debug",
+            "hidden": true,
+            "configuration": "Debug"
         },
         {
-            "name": "unixlike-clang-release",
-            "displayName": "clang Release",
-            "description": "Target Unix-like OS with the clang compiler, release build type",
-            "inherits": "config-unixlike-common",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            }
+            "name": "build-common-release",
+            "description": "Set build type to Release",
+            "hidden": true,
+            "configuration": "Release"
+        },
+        {
+            "name": "build-common-relwithdebinfo",
+            "description": "Set build type to Release",
+            "hidden": true,
+            "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "build-windows-msvc-developer-debug",
+            "displayName": "Debug",
+            "description": "Build msvc debug on windows (Developer Mode)",
+            "inherits": "build-common-debug",
+            "configurePreset": "windows-msvc-developer"
+        },
+        {
+            "name": "build-windows-msvc-user-debug",
+            "displayName": "Debug",
+            "description": "Build msvc debug on windows (User Mode)",
+            "inherits": "build-common-debug",
+            "configurePreset": "windows-msvc-user"
+        },
+        {
+            "name": "build-windows-msvc-developer-release",
+            "displayName": "Release",
+            "description": "Build msvc release on windows (Developer Mode)",
+            "inherits": "build-common-release",
+            "configurePreset": "windows-msvc-developer"
+        },
+        {
+            "name": "build-windows-msvc-user-release",
+            "displayName": "Release",
+            "description": "Build msvc release on windows (User Mode)",
+            "inherits": "build-common-release",
+            "configurePreset": "windows-msvc-user"
+        },
+        {
+            "name": "build-linux-gcc-debug",
+            "displayName": "Debug",
+            "description": "Build gcc debug on linux",
+            "inherits": "build-common-debug",
+            "configurePreset": "linux-gcc"
+        },
+        {
+            "name": "build-linux-gcc-release",
+            "displayName": "Release",
+            "description": "Build gcc release on linux",
+            "inherits": "build-common-release",
+            "configurePreset": "linux-gcc"
+        },
+        {
+            "name": "build-linux-clang-debug",
+            "displayName": "Debug",
+            "description": "Build clang debug on linux",
+            "inherits": "build-common-debug",
+            "configurePreset": "linux-clang"
+        },
+        {
+            "name": "build-linux-clang-release",
+            "displayName": "Release",
+            "description": "Build clang release on linux",
+            "inherits": "build-common-release",
+            "configurePreset": "linux-clang"
         }
     ],
     "testPresets": [
@@ -217,60 +227,88 @@
             }
         },
         {
-            "name": "test-windows-msvc-debug-developer-mode",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "name": "test-common-debug",
+            "description": "Test CMake settings that apply to debug configurations",
+            "hidden": true,
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-debug-developer-mode"
+            "configuration": "Debug"
         },
         {
-            "name": "test-windows-msvc-release-developer-mode",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
+            "name": "test-common-release",
+            "description": "Test CMake settings that apply to release configurations",
+            "hidden": true,
             "inherits": "test-common",
-            "configurePreset": "windows-msvc-release-developer-mode"
+            "configuration": "Release"
+        },
+        {
+            "name": "test-windows-msvc-developer-debug",
+            "displayName": "Debug",
+            "description": "Set Strict rules for windows msvc (Developer Mode) debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "windows-msvc-developer"
+        },
+        {
+            "name": "test-windows-msvc-developer-release",
+            "displayName": "Release",
+            "description": "Set Strict rules for windows msvc (Developer Mode) release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "windows-msvc-developer"
+        },
+        {
+            "name": "test-windows-msvc-user-debug",
+            "displayName": "Debug",
+            "description": "Set Strict rules for windows msvc (User Mode) debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "windows-msvc-user"
+        },
+        {
+            "name": "test-windows-msvc-user-release",
+            "displayName": "Release",
+            "description": "Set Strict rules for windows msvc (User Mode) release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "windows-msvc-user"
         },
         {
             "name": "test-windows-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-clang-debug"
+            "displayName": "Debug",
+            "description": "Set Strict rules for windows clang debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "windows-clang"
         },
         {
             "name": "test-windows-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "windows-clang-release"
+            "displayName": "Release",
+            "description": "Set Strict rules for windows clang release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "windows-clang"
         },
         {
             "name": "test-unixlike-gcc-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-debug"
+            "displayName": "Debug",
+            "description": "Set Strict rules for unixlike gcc debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "unixlike-gcc"
         },
         {
             "name": "test-unixlike-gcc-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-gcc-release"
+            "displayName": "Release",
+            "description": "Set Strict rules for unixlike gcc release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "unixlike-gcc"
         },
         {
             "name": "test-unixlike-clang-debug",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-clang-debug"
+            "displayName": "Debug",
+            "description": "Set Strict rules for unixlike clang debug tests",
+            "inherits": "test-common-debug",
+            "configurePreset": "unixlike-clang"
         },
         {
             "name": "test-unixlike-clang-release",
-            "displayName": "Strict",
-            "description": "Enable output and stop on failure",
-            "inherits": "test-common",
-            "configurePreset": "unixlike-clang-release"
+            "displayName": "Release",
+            "description": "Set Strict rules for unixlike clang release tests",
+            "inherits": "test-common-release",
+            "configurePreset": "unixlike-clang"
         }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,9 +10,7 @@
             "name": "conf-common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/out/build/${presetName}",
-            "installDir": "${sourceDir}/out/install/${presetName}"
+            "generator": "Ninja"
         },
         {
             "name": "conf-windows-common",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,16 +7,16 @@
     },
     "configurePresets": [
         {
-            "name": "conf-common",
+            "name": "config-common",
             "description": "General settings that apply to all configurations",
             "hidden": true,
             "generator": "Ninja"
         },
         {
-            "name": "conf-windows-common",
+            "name": "config-windows-common",
             "description": "Windows settings for MSBuild toolchain that apply to msvc and clang",
             "hidden": true,
-            "inherits": "conf-common",
+            "inherits": "config-common",
             "condition": {
                 "type": "equals",
                 "lhs": "${hostSystemName}",
@@ -36,10 +36,10 @@
             }
         },
         {
-            "name": "conf-unixlike-common",
+            "name": "config-unixlike-common",
             "description": "Unix-like OS settings for gcc and clang toolchains",
             "hidden": true,
-            "inherits": "conf-common",
+            "inherits": "config-common",
             "condition": {
                 "type": "inList",
                 "string": "${hostSystemName}",
@@ -58,7 +58,7 @@
             "name": "windows-msvc-debug-developer-mode",
             "displayName": "msvc Debug (Developer Mode)",
             "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
@@ -70,7 +70,7 @@
             "name": "windows-msvc-release-developer-mode",
             "displayName": "msvc Release (Developer Mode)",
             "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
@@ -82,7 +82,7 @@
             "name": "windows-msvc-debug-user-mode",
             "displayName": "msvc Debug (User Mode)",
             "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
@@ -94,7 +94,7 @@
             "name": "windows-msvc-release-user-mode",
             "displayName": "msvc Release (User Mode)",
             "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
@@ -106,7 +106,7 @@
             "name": "windows-clang-debug",
             "displayName": "clang Debug",
             "description": "Target Windows with the clang compiler, debug build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang-cl",
                 "CMAKE_CXX_COMPILER": "clang-cl",
@@ -122,7 +122,7 @@
             "name": "windows-clang-release",
             "displayName": "clang Release",
             "description": "Target Windows with the clang compiler, release build type",
-            "inherits": "conf-windows-common",
+            "inherits": "config-windows-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang-cl",
                 "CMAKE_CXX_COMPILER": "clang-cl",
@@ -138,7 +138,7 @@
             "name": "unixlike-gcc-debug",
             "displayName": "gcc Debug",
             "description": "Target Unix-like OS with the gcc compiler, debug build type",
-            "inherits": "conf-unixlike-common",
+            "inherits": "config-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
@@ -149,7 +149,7 @@
             "name": "unixlike-gcc-release",
             "displayName": "gcc Release",
             "description": "Target Unix-like OS with the gcc compiler, release build type",
-            "inherits": "conf-unixlike-common",
+            "inherits": "config-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_CXX_COMPILER": "g++",
@@ -160,7 +160,7 @@
             "name": "unixlike-clang-debug",
             "displayName": "clang Debug",
             "description": "Target Unix-like OS with the clang compiler, debug build type",
-            "inherits": "conf-unixlike-common",
+            "inherits": "config-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",
@@ -171,7 +171,7 @@
             "name": "unixlike-clang-release",
             "displayName": "clang Release",
             "description": "Target Unix-like OS with the clang compiler, release build type",
-            "inherits": "conf-unixlike-common",
+            "inherits": "config-unixlike-common",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,51 +55,75 @@
             }
         },
         {
+            "name": "config-developer-mode",
+            "description": "Set the flags to enable the development mode",
+            "hidden": true,
+            "cacheVariables": {
+                "ENABLE_DEVELOPER_MODE": "ON"
+            }
+        },
+        {
+            "name": "config-user-mode",
+            "description": "Set the flags to enable the user mode",
+            "hidden": true,
+            "cacheVariables": {
+                "ENABLE_DEVELOPER_MODE": "OFF"
+            }
+        },
+        {
             "name": "windows-msvc-debug-developer-mode",
             "displayName": "msvc Debug (Developer Mode)",
             "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "config-windows-common",
+            "inherits": [
+                "config-windows-common",
+                "config-developer-mode"
+            ],
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_DEVELOPER_MODE": "ON"
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
             "name": "windows-msvc-release-developer-mode",
             "displayName": "msvc Release (Developer Mode)",
             "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "config-windows-common",
+            "inherits": [
+                "config-windows-common",
+                "config-developer-mode"
+            ],
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_DEVELOPER_MODE": "ON"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
         },
         {
             "name": "windows-msvc-debug-user-mode",
             "displayName": "msvc Debug (User Mode)",
             "description": "Target Windows with the msvc compiler, debug build type",
-            "inherits": "config-windows-common",
+            "inherits": [
+                "config-windows-common",
+                "config-user-mode"
+            ],
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_DEVELOPER_MODE": "OFF"
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
             "name": "windows-msvc-release-user-mode",
             "displayName": "msvc Release (User Mode)",
             "description": "Target Windows with the msvc compiler, release build type",
-            "inherits": "config-windows-common",
+            "inherits": [
+                "config-windows-common",
+                "config-user-mode"
+            ],
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_DEVELOPER_MODE": "OFF"
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
             }
         },
         {


### PR DESCRIPTION
This PR contains several enhancement to the Cmake presets.

- Setting "Ninja Multi-Config" as the default generator should have several benefits for your IDEs (see also #15)
- Better structure of the hidden presets to facilitate better composability and extensibility! 
- Due to those changes different modes can be added depending on the use case (developer, user, ci etc.)

Currently we support 4 toolchains +1 mode option for msvc (thus 5 non-hidden configure presets) and the corresponding Debug and Release builds (thus 10 non-hidden buildPresets and 10 testPresets)

Since this is getting bigger and bigger with each new configuration option added to the project the configurePresets are doubled in numbers (e.g. msvc + mode option -> msvc Developer Mode and msvc User Mode) and the buildPresets and testPresets are quadrupled.
So, at this point I have the following questions. 

1. Shall we consider adding a CMakeUserPresets.json file to that repository that has the default user settings for developing that project? What I have in mind is to let the default build options to the CMakePresets.json and move the user specific options (and modes) to the CMakeUserPresets.json.
2. Should I also add support for RelWithDebInfo for completeness?
3. Is it necessary to be able to run tests both in Debug and Release?
4. Should the mode option be added in all supported toolchains currently it is only in msvc. gcc clang and clang-cl do not have that option

@ddalcino @aminya @lefticus @oskidan some feedback would be welcome!
Also, @oskidan and @ddalcino can you check that those changes are still functional in macOS to make sure I didn't mess with #16