### PR TITLE
Janitor: Add safe project name for cpp/hpp files

### DIFF
--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           # rename the CMake project to match the github project
           # ToDo use safe version here
-          sed -i "s/myproject/${{ github.event.repository.name }}/gi" CMakeLists.txt configured_files/config.hpp.in src/main.cpp
+          sed -i "s/myproject/${{ env.NEW_PROJECT }}/gi" CMakeLists.txt configured_files/config.hpp.in src/main.cpp
 
           # Update URL placeholders for project
           sed -i "s|%%myurl%%|${{ fromJson(steps.get_repo_meta.outputs.data).html_url }}|gi" CMakeLists.txt

--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -61,10 +61,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Use testing variables if still a template
+        if: fromJson(steps.get_repo_meta.outputs.data).is_template == true
+        run: |
+          # This name is unsafe because it is not a valid C++ identifier
+          # ToDo put more unsafe symbols and maybe prefix with number/underscores?
+          echo "NEW_PROJECT=my-unsafe-project-name" >> $GITHUB_ENV
+
+      - name: Add safe replacement variable versions
+        run: |
+          echo "ToDo: add the safe version!"
+
       # Rename all cpp_starter_project occurences to current repository and remove this workflow
       - name: Insert new org and project
         run: |
           # rename the CMake project to match the github project
+          # ToDo use safe version here
           sed -i "s/myproject/${{ github.event.repository.name }}/gi" CMakeLists.txt configured_files/config.hpp.in src/main.cpp
 
           # Update URL placeholders for project

--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -132,7 +132,8 @@ jobs:
       - name: Test simple configuration to make sure nothing broke
         run: |
           cmake -S . -B ./build -G "${{ matrix.generator }}" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.build_type }} -DENABLE_DEVELOPER_MODE:BOOL=${{ matrix.developer_mode }} -DOPT_ENABLE_COVERAGE:BOOL=OFF
-
+          # Build it because we may have broken something in the cpp/hpp files
+          cmake --build build
 
       - uses: EndBug/add-and-commit@v4
         # only commit and push if we are not a template project anymore!

--- a/.github/workflows/template-janitor.yml
+++ b/.github/workflows/template-janitor.yml
@@ -65,19 +65,19 @@ jobs:
         if: fromJson(steps.get_repo_meta.outputs.data).is_template == true
         run: |
           # This name is unsafe because it is not a valid C++ identifier
-          # ToDo put more unsafe symbols and maybe prefix with number/underscores?
-          echo "NEW_PROJECT=my-unsafe-project-name" >> $GITHUB_ENV
+          echo "NEW_PROJECT=my-unsafe.project" >> $GITHUB_ENV
 
       - name: Add safe replacement variable versions
         run: |
-          echo "ToDo: add the safe version!"
+          # hyphens and dots in c++ identifiers are forbidden. Use underscores instead.
+          NEW_SAFE_PROJECT=$(echo ${{ env.NEW_PROJECT }} | sed "s/-/_/g" | sed "s/\./_/g" )
+          echo "NEW_SAFE_PROJECT=$NEW_SAFE_PROJECT" >> $GITHUB_ENV 
 
       # Rename all cpp_starter_project occurences to current repository and remove this workflow
       - name: Insert new org and project
         run: |
           # rename the CMake project to match the github project
-          # ToDo use safe version here
-          sed -i "s/myproject/${{ env.NEW_PROJECT }}/gi" CMakeLists.txt configured_files/config.hpp.in src/main.cpp
+          sed -i "s/myproject/${{ env.NEW_SAFE_PROJECT }}/gi" CMakeLists.txt configured_files/config.hpp.in src/main.cpp
 
           # Update URL placeholders for project
           sed -i "s|%%myurl%%|${{ fromJson(steps.get_repo_meta.outputs.data).html_url }}|gi" CMakeLists.txt


### PR DESCRIPTION
This PR adds a new environment variable to the janitor called `NEW_SAFE_PROJECT`. This variable is intended to always be safe to use as a c++ identifier. 
For a start, hyphens and dots are converted into underscores.

Because the issue described in #21 is not caught by only configuring the project, the project is now also build.

The changes have been verified with the following project created from the template:
https://github.com/LtdSauce/Some-project.name