### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/actions/setup_cache/action.yml
+++ b/.github/actions/setup_cache/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # You might want to add .ccache to your cache configuration?
         path: |

--- a/.github/workflows/auto-clang-format.yml
+++ b/.github/workflows/auto-clang-format.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: DoozyX/clang-format-lint-action@v0.13
       with:
         source: '.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           script: |
             core.setFailed('There is a mismatch between configured llvm compiler and clang-tidy version chosen')
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Cache
         uses: ./.github/actions/setup_cache
@@ -182,7 +182,7 @@ jobs:
 
 
       - name: Publish to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           flags: ${{ runner.os }}
           name: ${{ runner.os }}-coverage

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -95,7 +95,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -110,4 +110,4 @@ jobs:
         cmake --build ./build --config ${{matrix.build_type}}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
This just updates the versions of the GitHub Actions being used, which make some warnings go away. As some of the versions are being deprecated next year, this should hopefully fix that.